### PR TITLE
* Created notification channels for android 8+ according to different…

### DIFF
--- a/com.aware.plugin.google.auth/src/main/java/com/aware/plugin/google/auth/Plugin.java
+++ b/com.aware.plugin.google.auth/src/main/java/com/aware/plugin/google/auth/Plugin.java
@@ -119,7 +119,7 @@ public class Plugin extends Aware_Plugin {
 
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_ONE_SHOT);
 
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, Aware.AWARE_NOTIFICATION_ID)
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL)
                 .setSmallIcon(R.drawable.ic_app_notification)
                 .setContentTitle(getString(R.string.app_name))
                 .setContentText(getString(R.string.noti_desc))
@@ -127,8 +127,10 @@ public class Plugin extends Aware_Plugin {
                 .setContentIntent(pendingIntent)
                 .setPriority(NotificationCompat.PRIORITY_HIGH);
 
+        notificationBuilder = Aware.setNotificationProperties(notificationBuilder, Aware.AWARE_NOTIFICATION_IMPORTANCE_GENERAL);
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-            notificationBuilder.setChannelId(Aware.AWARE_NOTIFICATION_ID);
+            notificationBuilder.setChannelId(Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL);
 
         Notification notification = notificationBuilder.build();
         notification.flags |= Notification.FLAG_NO_CLEAR;


### PR DESCRIPTION
… requirements:

General - Aware.NOTIFICATION_CHANNEL_GENERAL: for any generic & important notifications that require end-user interaction, or at minimum require the user to observe the notification
Data sync - Aware.NOTIFICATION_CHANNEL_DATASYNC: For uploading & download (e.g., sync study data or download/update plugins).
Silent - Aware.NOTIFICATION_CHANNEL_SILENT: For any notifications that are only required to exist in background.

* Added a global function to set notification properties according to channel importance (for v7 or older devices):
Aware.setNotificationPreference(NotificationCompat builder, int notificationImportance)
- Use Aware.AWARE_NOTIFICATION_IMPORTANCE_GENERAL etc. as second variable to set importance according to the v8+ channel.

* Removed unused notification channel creation from aware-client onCreate(). All required channels are created in aware-core.

* Updated all notification functionalities to use new channels and set their properties accordingly.